### PR TITLE
Add support for mouseEnter and mouseLeave events

### DIFF
--- a/src/components/Pipeline.vue
+++ b/src/components/Pipeline.vue
@@ -12,7 +12,7 @@
       :weight="item.weight" :lineStyle="lineStyle" />
     <pipeline-node v-for="(item,idx) in nodeList" :key="'node'+idx" :hint="item.hint" :status="item.status"
       :label="item.name" :x="item.x" :y="item.y" :node="item" :index="idx" :selected="selectedList[idx]"
-      @click="handleClick" />
+      @click="handleClick" @mouseenter="handleMouseEnter" @mouseleave="handleMouseLeave"/>
   </svg>
 </template>
 <script>
@@ -85,6 +85,12 @@ export default {
       this.$set(this.selectedList, index, true);
       this.selectedList[index] = true;
       this.$emit("select", node);
+    },
+    handleMouseEnter(index, node) {
+      this.$emit("mouseenter", node);
+    },
+    handleMouseLeave(index, node) {
+      this.$emit("mouseleave", node);
     },
     render() {
       this.service = new Pipeline(

--- a/src/components/PipelineNode.vue
+++ b/src/components/PipelineNode.vue
@@ -1,5 +1,5 @@
 <template>
-  <g :transform="'translate('+x+','+y+')'" :class="nodeClass">
+  <g :transform="'translate('+x+','+y+')'" :class="nodeClass" cursor="pointer" @click="handleClick" @mouseenter="handleMouseEnter" @mouseleave="handleMouseLeave">
 
     <pipeline-node-start v-if="status=='start'" :label="label" />
     <pipeline-node-end v-if="status=='end'" :label="label" />
@@ -39,7 +39,7 @@
     <title>{{hint}}</title>
 
     <!-- high light -->
-    <circle r="19" class="pipeline-node-hittarget" fill-opacity="0" stroke="none" cursor="pointer" @click="handleClick">
+    <circle r="19" class="pipeline-node-hittarget" fill-opacity="0" stroke="none">
     </circle>
     <g class="pipeline-selection-highlight" v-if="selected">
       <circle class="white-highlight" r="13" stroke-width="10"></circle>
@@ -109,6 +109,14 @@ export default {
       if (this.status != 'start' && this.status != 'end') {
         this.$emit('click', this.index, this.node)
       }
+    },
+    handleMouseEnter() {
+      this.nodeClass = 'pipeline-node-selected'
+      this.$emit('mouseenter', this.index, this.node)
+    },
+    handleMouseLeave() {
+      this.nodeClass = 'pipeline-node'
+      this.$emit('mouseleave', this.index, this.node)
     },
     getTextWidth(text, font) {
       // re-use canvas object for better performance


### PR DESCRIPTION
First, thank your for this great component. 

I was using the component and needed to show more information when hovering the nodes. So I pull this request that adds the mouseenter and mouseleave events to PipelineNodes. Using these, I will be able to show information not just when clicking, but also when hovering.

I also moved the click, moseenter and mouseleave, events from the PipelineNode circle, to its parent <g> tag. Doing so, you get the events not only when clicking/hovering on the node circle, but also on its LABEL and NAME. I don't know if you agree with this last change.

Hope everything is clear. Thanks in advance.